### PR TITLE
Feature/managing array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "bredmor/comment-analyzer",
-    "type": "library",
     "description": "Google Perspective Comment Analyzer API for PHP",
     "keywords": ["comment analyzer","moderation","perspective","api"],
     "homepage": "https://github.com/bredmor/comment-analyzer",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "bredmor/comment-analyzer",
+    "type": "library",
     "description": "Google Perspective Comment Analyzer API for PHP",
     "keywords": ["comment analyzer","moderation","perspective","api"],
     "homepage": "https://github.com/bredmor/comment-analyzer",

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -106,8 +106,8 @@ class Analyzer {
      * @param String $language - ISO 631-1 two-letter language code
      */
     public function removeLanguage(String $language): void {
-        if(in_array($language, $this->languages)) {
-            unset($this->languages[$language]);
+        if(($key = array_search($language, $this->languages)) !== false) {
+            unset($this->languages[$key]);
         }
     }
 

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -98,7 +98,7 @@ class Analyzer {
      * @param $language - ISO 631-1 two-letter language code
      */
     public function addLanguage(String $language): void {
-        $this->languages[] = $language;
+        $this->languages[$language] = $language;
     }
 
     /**
@@ -106,8 +106,8 @@ class Analyzer {
      * @param String $language - ISO 631-1 two-letter language code
      */
     public function removeLanguage(String $language): void {
-        if(($key = array_search($language, $this->languages)) !== false) {
-            unset($this->languages[$key]);
+        if((in_array($language, $this->languages, true)) !== false) {
+            unset($this->languages[$language]);
         }
     }
 
@@ -224,8 +224,7 @@ class Analyzer {
         $api_data['comment'] = ['text' => $comment->getText()];
 
         if(!empty($this->languages)) {
-            $this->languages = array_unique($this->languages);
-            $api_data['languages'] = $this->languages;
+            $api_data['languages'] = array_values($this->languages);
         }
 
         $api_data['requestedAttributes'] = [];


### PR DESCRIPTION
Hello,

Working with this library, we detect that removeLanguage functionality did not work, because unset() did not find $language as $this-languages[$language] as key value. Due to this, addLanguage creates  an array with several languages and with array_unique allows have 'en.pt,es' as language when those values are used in  buildApiData functionality-

Changes:

1. change languages as key => value in addLanguage allowing associate language key with its respective value to be removed later
2. strict in_array functionality to be remove as strue
3. remove array_unique and use array_values to thet languages values when data has been built

test script were run and the result was:
![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/27199727/207166268-ac229c39-42d6-4de3-9839-e3813699862f.png)

Thanks